### PR TITLE
Use generated GUIDs for filenames when creating GCS files

### DIFF
--- a/extensions/vroom-google-cloud-storage-extension/src/main/java/com/andydennie/vroom/extension/googlecloudstorage/biz/GcsFileBiz.java
+++ b/extensions/vroom-google-cloud-storage-extension/src/main/java/com/andydennie/vroom/extension/googlecloudstorage/biz/GcsFileBiz.java
@@ -29,7 +29,7 @@ public class GcsFileBiz<F extends IGcsFile, E extends GcsEntity<F, ?>>
     }
     @Override
     public String getServingUrl(LongKey fileKey) {
-        String result = ((E) getEntity()).getGcsFile(fileKey.get()).getServingUrl();
+        String result = ((E) getEntity()).getGcsFileObject(fileKey.get()).getServingUrl();
         return result;
     }
 }

--- a/extensions/vroom-google-cloud-storage-extension/src/main/java/com/andydennie/vroom/extension/googlecloudstorage/biz/GcsImageBiz.java
+++ b/extensions/vroom-google-cloud-storage-extension/src/main/java/com/andydennie/vroom/extension/googlecloudstorage/biz/GcsImageBiz.java
@@ -17,6 +17,7 @@ package com.andydennie.vroom.extension.googlecloudstorage.biz;
 import com.andydennie.vroom.core.domain.LongKey;
 import com.andydennie.vroom.extension.googlecloudstorage.domain.IGcsFile;
 import com.andydennie.vroom.extension.googlecloudstorage.service.datastore.GcsEntity;
+import com.andydennie.vroom.extension.googlecloudstorage.service.gcs.GcsFileObject;
 import com.andydennie.vroom.extension.googlecloudstorage.service.gcs.GcsImageObject;
 
 public class GcsImageBiz<F extends IGcsFile, E extends GcsEntity<F, ?>>
@@ -27,8 +28,8 @@ public class GcsImageBiz<F extends IGcsFile, E extends GcsEntity<F, ?>>
     }
 
     public String getServingUrl(LongKey fileKey, Integer size) {
-        F file = getEntity().get(fileKey.get());
-        GcsImageObject gcsImage = new GcsImageObject(file.getBucketName(), file.getFileName());
+        GcsFileObject gcsFileObject = ((E)getEntity()).getGcsFileObject(fileKey.get());
+        GcsImageObject gcsImage = new GcsImageObject(gcsFileObject.getBucketName(), gcsFileObject.getFileName());
         return gcsImage.getServingUrl(size);
     }
 }

--- a/extensions/vroom-google-cloud-storage-extension/src/main/java/com/andydennie/vroom/extension/googlecloudstorage/domain/GcsFile.java
+++ b/extensions/vroom-google-cloud-storage-extension/src/main/java/com/andydennie/vroom/extension/googlecloudstorage/domain/GcsFile.java
@@ -20,16 +20,29 @@ import com.andydennie.vroom.core.domain.LongKey;
 public class GcsFile extends File implements IGcsFile {
 
     private String mBucketName;
+    private String mGcsFileName;
 
     public GcsFile(final LongKey key, final String bucketName, final String fileName) {
         super(key, fileName);
         mBucketName = bucketName;
     }
 
+    @Override
+    public String getGcsFileName() {
+        return mGcsFileName;
+    }
+
+    @Override
+    public void setGcsFileName(final String gcsFileName) {
+        mGcsFileName = gcsFileName;
+    }
+
+    @Override
     public String getBucketName() {
         return mBucketName;
     }
 
+    @Override
     public void setBucketName(final String bucketName) {
         mBucketName = bucketName;
     }

--- a/extensions/vroom-google-cloud-storage-extension/src/main/java/com/andydennie/vroom/extension/googlecloudstorage/domain/IGcsFile.java
+++ b/extensions/vroom-google-cloud-storage-extension/src/main/java/com/andydennie/vroom/extension/googlecloudstorage/domain/IGcsFile.java
@@ -21,4 +21,8 @@ public interface IGcsFile extends IFile {
     public String getBucketName();
 
     public void setBucketName(final String bucketName);
+
+    public String getGcsFileName();
+
+    public void setGcsFileName(final String gcsFileName);
 }

--- a/extensions/vroom-google-cloud-storage-extension/src/main/java/com/andydennie/vroom/extension/googlecloudstorage/service/datastore/GcsDao.java
+++ b/extensions/vroom-google-cloud-storage-extension/src/main/java/com/andydennie/vroom/extension/googlecloudstorage/service/datastore/GcsDao.java
@@ -13,12 +13,28 @@ package com.andydennie.vroom.extension.googlecloudstorage.service.datastore;
  * limitations under the License.
  */
 
-import com.andydennie.vroom.core.domain.IFile;
 import com.andydennie.vroom.core.service.datastore.FileDao;
+import com.andydennie.vroom.extension.googlecloudstorage.domain.IGcsFile;
 
 
-public abstract class GcsDao<F extends IFile> extends FileDao<F> {
+public abstract class GcsDao<F extends IGcsFile> extends FileDao<F> {
     private String bucketName;
+    private String gcsFileName;
+
+    @Override
+    public void fromDomainObject(final F file) {
+        bucketName = file.getBucketName();
+        gcsFileName = file.getGcsFileName();
+        super.fromDomainObject(file);
+    }
+
+    public String getGcsFileName() {
+        return gcsFileName;
+    }
+
+    public void setGcsFileName(final String gcsFileName) {
+        this.gcsFileName = gcsFileName;
+    }
 
     public String getBucketName() {
         return bucketName;

--- a/extensions/vroom-google-cloud-storage-extension/src/main/java/com/andydennie/vroom/extension/googlecloudstorage/service/datastore/GcsEntity.java
+++ b/extensions/vroom-google-cloud-storage-extension/src/main/java/com/andydennie/vroom/extension/googlecloudstorage/service/datastore/GcsEntity.java
@@ -1,6 +1,6 @@
 package com.andydennie.vroom.extension.googlecloudstorage.service.datastore;
 /*
- * Copyright (c) 2013 Fizz Buzz LLC
+ * Copyright (c) 2014 Fizz Buzz LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.UUID;
 
 public class GcsEntity<F extends IGcsFile, DAO extends GcsDao<F>> extends FileEntity<F, DAO> {
     private final Logger mLogger = LoggerFactory.getLogger(PackageLogger.TAG);
@@ -30,9 +31,12 @@ public class GcsEntity<F extends IGcsFile, DAO extends GcsDao<F>> extends FileEn
         super(doClass, daoClass);
     }
 
-    public void create(final F file, GcsFileOptions gcsFileOptions, final byte[] content) {
-        // first, write the file to GCS
-        GcsFileObject gcsFileObject = new GcsFileObject(file.getBucketName(), file.getFileName(), gcsFileOptions);
+    public void create(final F file, final String gcsBucketName, GcsFileOptions gcsFileOptions, final byte[] content) {
+        // first, write the file to GCS.  Generate a GUID for the filename, to ensure we don't overwrite an existing
+        // file with the same name.
+        file.setGcsFileName(UUID.randomUUID().toString());
+        file.setBucketName(gcsBucketName);
+        GcsFileObject gcsFileObject = new GcsFileObject(file.getBucketName(), file.getGcsFileName(), gcsFileOptions);
         try {
             gcsFileObject.write(content);
         } catch (IOException e) {
@@ -40,13 +44,13 @@ public class GcsEntity<F extends IGcsFile, DAO extends GcsDao<F>> extends FileEn
             throw new GcsException(e);
         }
 
-        // now save an entity to the datastore, referencing the GCS file
+        // now save an entity to the datastore, referencing the GCS file.
         super.create(file);
     }
 
     @Override
     public void delete(final Long key) {
-        GcsFileObject gcsFileObject = getGcsFile(key);
+        GcsFileObject gcsFileObject = getGcsFileObject(key);
         try {
             gcsFileObject.delete();
             super.delete(key);
@@ -56,16 +60,9 @@ public class GcsEntity<F extends IGcsFile, DAO extends GcsDao<F>> extends FileEn
     }
 
 
-    public GcsFileObject getGcsFile(Long key) {
-        F file = get(key);
-        GcsFileObject result = new GcsFileObject(file.getBucketName(), file.getFileName());
-        return result;
-    }
-
-    @Override
-    protected DAO createDao(final F file) {
-        DAO result = super.createDao(file);
-        result.setBucketName(file.getBucketName());
+    public GcsFileObject getGcsFileObject(Long key) {
+        DAO dao = loadDao(key);
+        GcsFileObject result = new GcsFileObject(dao.getBucketName(), dao.getGcsFileName());
         return result;
     }
 }

--- a/samples/vroom-sample-webservice/src/main/java/com/andydennie/vroom/sample/webservice/api/resource/ImageResource.java
+++ b/samples/vroom-sample-webservice/src/main/java/com/andydennie/vroom/sample/webservice/api/resource/ImageResource.java
@@ -17,6 +17,7 @@ package com.andydennie.vroom.sample.webservice.api.resource;
 import com.andydennie.vroom.extension.googlecloudstorage.api.resource.GcsImageResource;
 import com.andydennie.vroom.extension.googlecloudstorage.domain.GcsFile;
 import com.andydennie.vroom.sample.webservice.biz.ImageBiz;
+import org.restlet.resource.Delete;
 import org.restlet.resource.Get;
 import org.restlet.resource.ResourceException;
 
@@ -34,6 +35,16 @@ public class ImageResource
             doCatch(e);
         }
         return result;
+    }
+
+    @Override
+    @Delete
+    public void deleteResource() {
+        try {
+            super.deleteResource();
+        } catch (RuntimeException e) {
+            doCatch(e);
+        }
     }
 
     @Override

--- a/samples/vroom-sample-webservice/src/main/java/com/andydennie/vroom/sample/webservice/service/datastore/ImageEntity.java
+++ b/samples/vroom-sample-webservice/src/main/java/com/andydennie/vroom/sample/webservice/service/datastore/ImageEntity.java
@@ -55,8 +55,6 @@ public class ImageEntity extends GcsEntity<GcsFile, ImageDao> {
                 .cacheControl("public, max-age=31449600")
                 .build();
 
-        // assign the bucket name into the domain object
-        file.setBucketName(BUCKET_NAME);
-        super.create(file, gcsFileOptions, content);
+        super.create(file, BUCKET_NAME, gcsFileOptions, content);
     }
 }


### PR DESCRIPTION
... to avoid overwriting existing files and URL encoding issues.
