### PR TITLE
add lifecycle callbacks Entities and Biz objects

### DIFF
--- a/vroom-core/src/main/java/com/fizzbuzz/vroom/core/biz/EntityBiz.java
+++ b/vroom-core/src/main/java/com/fizzbuzz/vroom/core/biz/EntityBiz.java
@@ -19,7 +19,6 @@ import com.fizzbuzz.vroom.core.domain.LongKey;
 import com.fizzbuzz.vroom.core.service.datastore.IEntity;
 
 import java.util.Collection;
-import java.util.List;
 
 public abstract class EntityBiz<E extends IEntityObject> implements IEntityBiz<E>, ICollectionBiz<E> {
     private IEntity<E> mEntity;
@@ -33,12 +32,16 @@ public abstract class EntityBiz<E extends IEntityObject> implements IEntityBiz<E
     }
 
     @Override
-    public void add(final E entityObject) {
-        getEntity().create(entityObject);
+    public void add(final E domainObject) {
+        onAdd(domainObject);
+        getEntity().create(domainObject);
     }
 
     @Override
     public void add(Collection<E> domainObjects) {
+        for (E domainObject : domainObjects) {
+            onAdd(domainObject);
+        }
         getEntity().create(domainObjects);
     }
 
@@ -48,7 +51,7 @@ public abstract class EntityBiz<E extends IEntityObject> implements IEntityBiz<E
     }
 
     @Override
-    public List<E> getAll() {
+    public Collection<E> getAll() {
         return mEntity.getAll();
     }
 
@@ -62,12 +65,14 @@ public abstract class EntityBiz<E extends IEntityObject> implements IEntityBiz<E
     }
 
     @Override
-    public void update(final E entityObject) {
-        mEntity.update(entityObject);
+    public void update(final E domainObject) {
+        onUpdate(domainObject);
+        mEntity.update(domainObject);
     }
 
     @Override
     public void delete(final LongKey key) {
+        onDelete(mEntity.get(key.get()));
         mEntity.delete(key.get());
     }
 
@@ -82,15 +87,25 @@ public abstract class EntityBiz<E extends IEntityObject> implements IEntityBiz<E
 
     @Override
     public void delete(Collection<E> domainObjects) {
+        for (E domainObject : domainObjects) {
+            onDelete(domainObject);
+        }
         getEntity().delete(domainObjects);
-    }
-
-    public void deleteKeys(Collection<LongKey> keys) {
-        getEntity().deleteKeys(LongKey.toValues(keys));
     }
 
     @Override
     public void deleteAll() {
+        Collection<E> domainObjects = getAll();
+        for (E domainObject : domainObjects) {
+            onDelete(domainObject);
+        }
         getEntity().deleteAll();
+    }
+
+    protected void onAdd(E entityObject) {
+    }
+    protected void onUpdate(E entityObject) {
+    }
+    protected void onDelete(E entityObject) {
     }
 }

--- a/vroom-core/src/main/java/com/fizzbuzz/vroom/core/biz/ICollectionBiz.java
+++ b/vroom-core/src/main/java/com/fizzbuzz/vroom/core/biz/ICollectionBiz.java
@@ -15,14 +15,13 @@ package com.fizzbuzz.vroom.core.biz;
  */
 
 import java.util.Collection;
-import java.util.List;
 
 public interface ICollectionBiz<DO> {
     /**
-     * Returns the list of domain objects within a collection
-     * @return the list of domain objects
+     * Returns a collection of domain objects
+     * @return the collection
      */
-    public List<DO> getAll();
+    public Collection<DO> getAll();
 
     /**
      * Adds a domain object to the collection.

--- a/vroom-core/src/main/java/com/fizzbuzz/vroom/core/service/datastore/IEntity.java
+++ b/vroom-core/src/main/java/com/fizzbuzz/vroom/core/service/datastore/IEntity.java
@@ -107,13 +107,6 @@ public interface IEntity<EO extends IEntityObject> {
     public void delete(final Collection<EO> domainObjects);
 
     /**
-     * Deletes entities corresponding to those in a collection of domain objects
-     *
-     * @param keys the keys of the entities to delete
-     */
-    public void deleteKeys(final Collection<Long> keys);
-
-    /**
      * Allocates a single ID for an entity which is not part of an entity group
      *
      * @return an allocated ID


### PR DESCRIPTION
 EntityBiz invokes onAdd, onUpdate, and onDelete methods to inform
 subclasses that a lifecycle action is taking place on a domain object.

 VroomEntity invokes onCreate, onUpdate, and onDelete methods to inform
 subclasses that a lifecycle action is taking place on a domain object.

 VroomEntity also invokes onSaveDao and onDeleteDao to inform subclasses
 that a lifecycle action is taking place on a DAO.
